### PR TITLE
composer: Separate rc and xml from service

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,140 +1,101 @@
+composer_srcs = ["*.cpp"]
+
 soong_config_module_type {
-    name: "qtidisplay_cc_defaults",
+    name: "dolby_vision_cc_defaults",
     module_type: "cc_defaults",
-    config_namespace: "qtidisplay",
-    bool_variables: [
-        "drmpp",
-        "headless",
-        "llvmsa",
-        "gralloc4",
-        "udfps",
-        "default",
-    ],
-    properties: [
-        "cflags",
-        "srcs",
-        "header_libs",
-    ],
+    config_namespace: "dolby_vision",
+    bool_variables: ["enabled"],
+    properties: ["cflags"],
 }
 
-qtidisplay_cc_defaults {
-    name: "qtidisplay_common_defaults",
-    cflags: [
-        "-Wno-missing-field-initializers",
-        "-Wall",
-        "-Werror",
-    ],
-    shared_libs: [
-        "liblog",
-        "libcutils",
-        "libutils",
-    ],
+dolby_vision_cc_defaults {
+    name: "dolby_vision_defaults",
     soong_config_variables: {
-        drmpp: {
-            cflags: ["-DPP_DRM_ENABLE"],
-        },
-        headless: {
-            cflags: ["-DTARGET_HEADLESS", "-DQMAA"],
-        },
-        llvmsa: {
+        enabled: {
             cflags: [
-                "--compile-and-analyze",
-                "--analyzer-perf",
+                "-DTARGET_SUPPORTS_DOLBY_VISION",
             ],
         },
-        gralloc4: {
-            cflags: ["-DTARGET_USES_GRALLOC4"],
-        },
-        udfps: {
-            cflags: ["-DUDFPS_ZPOS"],
-        },
     },
 }
 
-qtidisplay_cc_defaults {
-    name: "qtidisplay_defaults",
-    defaults: ["qtidisplay_common_defaults"],
-    soong_config_variables: {
-        default: {
-            header_libs: ["display_headers", "qti_kernel_headers"],
-        },
-        headless: {
-            header_libs: ["display_headers"],
-        },
+cc_binary {
+
+    name: "vendor.qti.hardware.display.composer-service",
+    defaults: ["qtidisplay_defaults", "dolby_vision_defaults"],
+    sanitize: {
+        integer_overflow: true,
     },
-}
-
-qtidisplay_cc_defaults {
-    name: "qti_qmaa_display_defaults",
-    defaults: ["qtidisplay_common_defaults"],
-    header_libs: ["qmaa_display_headers"],
-}
-
-cc_library_headers {
-    name: "display_debug_headers",
     vendor: true,
-    export_include_dirs: [
-        "libdebug",
+    relative_install_path: "hw",
+    header_libs: [
+        "display_headers",
+        "qti_kernel_headers",
     ],
-}
 
-cc_library_headers {
-    name: "display_headers",
-    vendor: true,
-    export_include_dirs: [
-        "include",
-        "libcopybit",
-        "libdrmutils",
-        "libqdutils",
-        "libqservice",
-        "gpu_tonemapper",
-        "sdm/include",
-        "gralloc",
+    cflags: [
+        "-Wno-missing-field-initializers",
+        "-Wno-unused-parameter",
+        "-DLOG_TAG=\"SDM\"",
+    ],
+
+    shared_libs: [
+        "libbinder",
+        "libhardware",
         "libhistogram",
-        "libmemutils",
+        "libutils",
+        "libcutils",
+        "libsync",
+        "libc++",
+        "liblog",
+        "libhidlbase",
+        "liblog",
+        "libfmq",
+        "libhardware_legacy",
+        "libsdmcore",
+        "libqservice",
+        "libqdutils",
+        "libqdMetaData",
+        "libdisplaydebug",
+        "libsdmutils",
+        "libui",
+        "libgrallocutils",
+        "libgpu_tonemapper",
+        "libEGL",
+        "libGLESv2",
+        "libGLESv3",
+        "vendor.qti.hardware.display.composer@3.0",
+        "android.hardware.graphics.composer@2.1",
+        "android.hardware.graphics.composer@2.2",
+        "android.hardware.graphics.composer@2.3",
+        "android.hardware.graphics.composer@2.4",
+        "android.hardware.graphics.mapper@2.0",
+        "android.hardware.graphics.mapper@2.1",
+        "android.hardware.graphics.mapper@3.0",
+        "android.hardware.graphics.allocator@2.0",
+        "android.hardware.graphics.allocator@3.0",
+        "libdisplayconfig.qti",
+        "libdrm",
     ],
-    header_libs: [
-        "libhardware_headers",
-        "display_intf_headers",
-        "display_debug_headers",
-    ],
-    export_header_lib_headers: [
-        "libhardware_headers",
-        "display_intf_headers",
-        "display_debug_headers",
+    srcs: composer_srcs,
+
+    required: [
+        "vendor.qti.hardware.display.composer-service.rc",
+        "vendor.qti.hardware.display.composer-service.xml",
     ],
 }
 
-cc_library_headers {
-    name: "qmaa_display_headers",
+prebuilt_etc {
+    name: "vendor.qti.hardware.display.composer-service.rc",
+    src: "vendor.qti.hardware.display.composer-service.rc",
+    filename_from_src: true,
+    sub_dir: "init",
     vendor: true,
-    export_include_dirs: [
-
-    ],
-    header_libs: [
-        "display_debug_headers",
-    ],
-    export_header_lib_headers: [
-        "display_debug_headers",
-    ],
 }
-
-subdirs = [
-    "init",
-    "libqservice",
-    "libqdutils",
-    "libddebug",
-    "libdrmutils",
-    "libmemtrack",
-    "libhistogram",
-    "liblight",
-    "composer",
-    "gralloc",
-    "gpu_tonemapper",
-    "hdmi_cec",
-    "sde-drm",
-    "sdm/libs/utils",
-    "sdm/libs/core",
-    "qmaa",
-    "libmemutils",
-]
+prebuilt_etc_xml {
+    name: "vendor.qti.hardware.display.composer-service.xml",
+    src: "vendor.qti.hardware.display.composer-service.xml",
+    filename_from_src: true,
+    sub_dir: "vintf/manifest",
+    vendor: true,
+}


### PR DESCRIPTION
This allows overriding the service with a prebuilt without running into conflicts that are unresolvable without renaming files.